### PR TITLE
bacon: remove wifi.supplicant_scan_interval in system.prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -76,4 +76,3 @@ persist.timed.enable=true
 
 # Wifi
 wifi.interface=wlan0
-wifi.supplicant_scan_interval=15


### PR DESCRIPTION
It is in overlay now, and default is 15000ms also.

Change-Id: Iafb7eb8f5215831496d7f2b29064f977bc6cd23e
